### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/snap/boost/bloom_filter/doc/html/bibliography.html
+++ b/snap/boost/bloom_filter/doc/html/bibliography.html
@@ -82,7 +82,7 @@
 	<li>
 	  [Kirsch et al., 2008] 
 	  A. Kirsch, M. Mitzenmacher. 
-	  <a href="http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf">
+	  <a href="https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf">
 	    <em>Less Hashing, Same Performance: Building a Better Bloom Filter</em>.
 	  </a>
 	  In <em>Random Structures and Algorithms</em>, pages 187-219.


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author